### PR TITLE
add: editorconfig can help maintain style.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+
+# https://github.com/vuejs/vetur/issues/1319
+# CRLF will cause some error
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
Fixes #1 

> The problem is related to the configured line endings. Switching VS Code to LF and it works as expected, CRLF results in the error.
> see vetur issue https://github.com/vuejs/vetur/issues/1319